### PR TITLE
Kernel GS migration fix optimization

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -864,8 +864,11 @@ struct task_struct {
 	unsigned			in_page_owner:1;
 #endif
 #ifdef CONFIG_SYMBIOTE
-  /* Used to signal symbiote status. */
+    /* Used to signal symbiote status. */
 	unsigned			symbiote_elevated:1;
+
+	/* Used to indicate when a symbiote thread migrated cores */
+	unsigned 			symbiote_migrated:1;
 #endif
 
 	unsigned long			atomic_flags; /* Flags requiring atomic access. */

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2232,7 +2232,7 @@ static struct rq *move_queued_task(struct rq *rq, struct rq_flags *rf,
 #ifdef CONFIG_SYMBIOTE
 	// Indicate that a symbiote thread has migrated cores in order
 	// to properly "fix" the gsbase value in context_switch() call.
-    if (p->symbiote_elevated && old_cpu != new_cpu) {
+    if (p->symbiote_elevated) {
 		p->symbiote_migrated = 1;
 	}
 #endif
@@ -4675,6 +4675,8 @@ context_switch(struct rq *rq, struct task_struct *prev,
 	unsigned long long kernel_gs;
 
     if (next->symbiote_migrated) {
+		BUG_ON(smp_processor_id() == task_cpu(next));
+
 		// Read the GSBASE value from the MSR
 		asm volatile("rdmsr" : "=a" (gs_low), "=d" (gs_high) : "c" (0xC0000101));
 		

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2211,6 +2211,11 @@ static inline bool is_cpu_allowed(struct task_struct *p, int cpu)
 static struct rq *move_queued_task(struct rq *rq, struct rq_flags *rf,
 				   struct task_struct *p, int new_cpu)
 {
+#ifdef CONFIG_SYMBIOTE
+	int old_cpu;
+	old_cpu = task_cpu(p);
+#endif
+
 	lockdep_assert_rq_held(rq);
 
 	deactivate_task(rq, p, DEQUEUE_NOCLOCK);
@@ -2223,6 +2228,14 @@ static struct rq *move_queued_task(struct rq *rq, struct rq_flags *rf,
 	BUG_ON(task_cpu(p) != new_cpu);
 	activate_task(rq, p, 0);
 	check_preempt_curr(rq, p, 0);
+
+#ifdef CONFIG_SYMBIOTE
+	// Indicate that a symbiote thread has migrated cores in order
+	// to properly "fix" the gsbase value in context_switch() call.
+    if (p->symbiote_elevated && old_cpu != new_cpu) {
+		p->symbiote_migrated = 1;
+	}
+#endif
 
 	return rq;
 }
@@ -4657,15 +4670,11 @@ context_switch(struct rq *rq, struct task_struct *prev,
 	// a target core and every time there is a context switch, and
 	// since the symbiote thread is already elevated, reading USERGS
 	// from MSR would give us the correct gsbase value for the target core.
-	//
-	// One possible optimization would be to run this code only when
-	// an elevated thread migrates onto a different core but for now
-	// doing this right before every context switch is sufficient.
 
 	unsigned int gs_low, gs_high;
 	unsigned long long kernel_gs;
 
-    if (next->symbiote_elevated) {
+    if (next->symbiote_migrated) {
 		// Read the GSBASE value from the MSR
 		asm volatile("rdmsr" : "=a" (gs_low), "=d" (gs_high) : "c" (0xC0000101));
 		
@@ -4674,6 +4683,9 @@ context_switch(struct rq *rq, struct task_struct *prev,
 
 		// Update the next task's gsbase value.
 		next->thread.gsbase = kernel_gs;
+
+		// Indicate that the migration has been handled
+		next->symbiote_migrated = 0;
 	}
 #endif
 

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -4675,7 +4675,7 @@ context_switch(struct rq *rq, struct task_struct *prev,
 	unsigned long long kernel_gs;
 
     if (next->symbiote_migrated) {
-		BUG_ON(smp_processor_id() == task_cpu(next));
+		BUG_ON(smp_processor_id() != task_cpu(next));
 
 		// Read the GSBASE value from the MSR
 		asm volatile("rdmsr" : "=a" (gs_low), "=d" (gs_high) : "c" (0xC0000101));


### PR DESCRIPTION
Previously, our kernel GS fix took place inside the `context_switch` function and every time any task was switched to, it would check if the thread is a symbiote thread, and if so, it would "fix-up" the kernel gs value for that task.

The new design stores an extra bit in the task_struct that identifies if the symbiote thread has recently migrated from one core to another. This design allows to "fix-up" kernel gs only after core migration instead of every context switch.