### PR TITLE
Elevate capability

### DIFF
--- a/include/uapi/linux/capability.h
+++ b/include/uapi/linux/capability.h
@@ -418,7 +418,11 @@ struct vfs_ns_cap_data {
 
 #define CAP_CHECKPOINT_RESTORE	40
 
-#define CAP_LAST_CAP         CAP_CHECKPOINT_RESTORE
+/* Allow performing the elevate syscall and make use of symbiote functionality */
+
+#define CAP_SYMBI_ELEV  41
+
+#define CAP_LAST_CAP         CAP_SYMBI_ELEV
 
 #define cap_valid(x) ((x) >= 0 && (x) <= CAP_LAST_CAP)
 

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1089,6 +1089,9 @@ void symbi_debug_entry(struct pt_regs *regs, struct SymbiReg *sreg){
 SYSCALL_DEFINE1(elevate, unsigned long, flags)
 {
 #ifdef CONFIG_SYMBIOTE
+  if (!capable(CAP_SYS_ADMIN))
+	return -EPERM;
+
   struct pt_regs *regs;
 
   /* local_irq_disable(); */

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1095,7 +1095,7 @@ SYSCALL_DEFINE1(elevate, unsigned long, flags)
   struct SymbiReg sreg;
   sreg.raw = flags;
 
-  if (!capable(CAP_SYS_ADMIN))
+  if (!capable(CAP_SYMBI_ELEV))
 	return -EPERM;
 
   // User's registers

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1089,14 +1089,14 @@ void symbi_debug_entry(struct pt_regs *regs, struct SymbiReg *sreg){
 SYSCALL_DEFINE1(elevate, unsigned long, flags)
 {
 #ifdef CONFIG_SYMBIOTE
-  if (!capable(CAP_SYS_ADMIN))
-	return -EPERM;
-
   struct pt_regs *regs;
 
   /* local_irq_disable(); */
   struct SymbiReg sreg;
   sreg.raw = flags;
+
+  if (!capable(CAP_SYS_ADMIN))
+	return -EPERM;
 
   // User's registers
   regs = (struct pt_regs *)this_cpu_read(cpu_current_top_of_stack) - 1;

--- a/security/selinux/include/classmap.h
+++ b/security/selinux/include/classmap.h
@@ -28,9 +28,9 @@
 
 #define COMMON_CAP2_PERMS  "mac_override", "mac_admin", "syslog", \
 		"wake_alarm", "block_suspend", "audit_read", "perfmon", "bpf", \
-		"checkpoint_restore"
+		"checkpoint_restore", "symbi_elev"
 
-#if CAP_LAST_CAP > CAP_CHECKPOINT_RESTORE
+#if CAP_LAST_CAP > CAP_SYMBI_ELEV
 #error New capability defined, please update COMMON_CAP2_PERMS.
 #endif
 


### PR DESCRIPTION
Added a new capability called CAP_SYMBI_ELEV that is necessary to perform the elevate() system call.
In order to make use of that capability, add it to the binary as follows:
`sudo setcap 41=eip /path/to/binary`